### PR TITLE
feat(todos): Todo CRUD 기능 구현

### DIFF
--- a/src/app/api/todos/[id]/route.ts
+++ b/src/app/api/todos/[id]/route.ts
@@ -1,0 +1,32 @@
+import { NextRequest, NextResponse } from "next/server";
+import { todoStore } from "@/lib/store";
+import { UpdateTodoRequest } from "@/types/todo";
+
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params;
+  const body: UpdateTodoRequest = await request.json();
+
+  const updated = todoStore.update(id, body);
+  if (!updated) {
+    return NextResponse.json({ error: "Todo not found" }, { status: 404 });
+  }
+
+  return NextResponse.json(updated);
+}
+
+export async function DELETE(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params;
+  const deleted = todoStore.delete(id);
+
+  if (!deleted) {
+    return NextResponse.json({ error: "Todo not found" }, { status: 404 });
+  }
+
+  return new NextResponse(null, { status: 204 });
+}

--- a/src/app/api/todos/route.ts
+++ b/src/app/api/todos/route.ts
@@ -1,0 +1,31 @@
+import { NextRequest, NextResponse } from "next/server";
+import { todoStore } from "@/lib/store";
+import { CreateTodoRequest } from "@/types/todo";
+
+export async function GET() {
+  const todos = todoStore.getAll();
+  return NextResponse.json(todos);
+}
+
+export async function POST(request: NextRequest) {
+  const body: CreateTodoRequest = await request.json();
+
+  if (!body.title || typeof body.title !== "string") {
+    return NextResponse.json({ error: "title is required" }, { status: 400 });
+  }
+
+  const trimmed = body.title.trim();
+  if (trimmed.length === 0) {
+    return NextResponse.json({ error: "title cannot be empty" }, { status: 400 });
+  }
+
+  if (trimmed.length > 200) {
+    return NextResponse.json(
+      { error: "title must be 200 characters or less" },
+      { status: 400 }
+    );
+  }
+
+  const todo = todoStore.create(trimmed);
+  return NextResponse.json(todo, { status: 201 });
+}

--- a/src/app/todos/page.tsx
+++ b/src/app/todos/page.tsx
@@ -1,0 +1,11 @@
+import { Metadata } from "next";
+import { TodoPage } from "@/components/todos/TodoPage";
+
+export const metadata: Metadata = {
+  title: "Todo List",
+  description: "할 일 목록 관리",
+};
+
+export default function Page() {
+  return <TodoPage />;
+}

--- a/src/components/todos/TodoForm.tsx
+++ b/src/components/todos/TodoForm.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import { useState, FormEvent } from "react";
+
+interface TodoFormProps {
+  onCreate: (title: string) => Promise<void>;
+}
+
+export function TodoForm({ onCreate }: TodoFormProps) {
+  const [title, setTitle] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+
+  async function handleSubmit(e: FormEvent) {
+    e.preventDefault();
+    const trimmed = title.trim();
+    if (!trimmed || submitting) return;
+
+    setSubmitting(true);
+    try {
+      await onCreate(trimmed);
+      setTitle("");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="flex gap-2">
+      <input
+        type="text"
+        value={title}
+        onChange={(e) => setTitle(e.target.value)}
+        placeholder="할 일을 입력하세요..."
+        maxLength={200}
+        disabled={submitting}
+        className="flex-1 px-3 py-2 text-sm rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-800 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:opacity-50"
+      />
+      <button
+        type="submit"
+        disabled={!title.trim() || submitting}
+        className="px-4 py-2 text-sm font-medium rounded-lg bg-blue-500 text-white hover:bg-blue-600 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+      >
+        {submitting ? "추가 중..." : "추가"}
+      </button>
+    </form>
+  );
+}

--- a/src/components/todos/TodoItem.tsx
+++ b/src/components/todos/TodoItem.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import { useState } from "react";
+import { Todo } from "@/types/todo";
+
+interface TodoItemProps {
+  todo: Todo;
+  onToggle: (id: string) => Promise<void>;
+  onDelete: (id: string) => Promise<void>;
+}
+
+export function TodoItem({ todo, onToggle, onDelete }: TodoItemProps) {
+  const [busy, setBusy] = useState(false);
+
+  async function handleToggle() {
+    if (busy) return;
+    setBusy(true);
+    try {
+      await onToggle(todo.id);
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function handleDelete() {
+    if (busy) return;
+    setBusy(true);
+    try {
+      await onDelete(todo.id);
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <li className="flex items-center gap-3 p-3 rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800">
+      <input
+        type="checkbox"
+        checked={todo.completed}
+        onChange={handleToggle}
+        disabled={busy}
+        className="h-4 w-4 cursor-pointer accent-blue-500 disabled:cursor-not-allowed"
+      />
+      <span
+        className={`flex-1 text-sm ${
+          todo.completed
+            ? "line-through text-gray-400 dark:text-gray-500"
+            : "text-gray-800 dark:text-gray-100"
+        }`}
+      >
+        {todo.title}
+      </span>
+      <button
+        onClick={handleDelete}
+        disabled={busy}
+        className="text-gray-400 hover:text-red-500 dark:hover:text-red-400 transition-colors disabled:cursor-not-allowed disabled:opacity-50"
+        aria-label="삭제"
+      >
+        ✕
+      </button>
+    </li>
+  );
+}

--- a/src/components/todos/TodoList.tsx
+++ b/src/components/todos/TodoList.tsx
@@ -1,0 +1,26 @@
+import { Todo } from "@/types/todo";
+import { TodoItem } from "./TodoItem";
+
+interface TodoListProps {
+  todos: Todo[];
+  onToggle: (id: string) => Promise<void>;
+  onDelete: (id: string) => Promise<void>;
+}
+
+export function TodoList({ todos, onToggle, onDelete }: TodoListProps) {
+  if (todos.length === 0) {
+    return (
+      <p className="text-center text-sm text-gray-400 dark:text-gray-500 py-8">
+        할 일이 없습니다. 새 항목을 추가해보세요!
+      </p>
+    );
+  }
+
+  return (
+    <ul className="flex flex-col gap-2">
+      {todos.map((todo) => (
+        <TodoItem key={todo.id} todo={todo} onToggle={onToggle} onDelete={onDelete} />
+      ))}
+    </ul>
+  );
+}

--- a/src/components/todos/TodoPage.tsx
+++ b/src/components/todos/TodoPage.tsx
@@ -1,0 +1,82 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import { Todo } from "@/types/todo";
+import { TodoForm } from "./TodoForm";
+import { TodoList } from "./TodoList";
+
+export function TodoPage() {
+  const [todos, setTodos] = useState<Todo[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchTodos = useCallback(async () => {
+    try {
+      const res = await fetch("/api/todos");
+      if (!res.ok) throw new Error("목록을 불러오는 데 실패했습니다.");
+      const data: Todo[] = await res.json();
+      setTodos(data);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "오류가 발생했습니다.");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchTodos();
+  }, [fetchTodos]);
+
+  async function handleCreate(title: string) {
+    const res = await fetch("/api/todos", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ title }),
+    });
+    if (!res.ok) throw new Error("생성에 실패했습니다.");
+    const newTodo: Todo = await res.json();
+    setTodos((prev) => [newTodo, ...prev]);
+  }
+
+  async function handleToggle(id: string) {
+    const todo = todos.find((t) => t.id === id);
+    if (!todo) return;
+
+    const res = await fetch(`/api/todos/${id}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ completed: !todo.completed }),
+    });
+    if (!res.ok) throw new Error("업데이트에 실패했습니다.");
+    const updated: Todo = await res.json();
+    setTodos((prev) => prev.map((t) => (t.id === id ? updated : t)));
+  }
+
+  async function handleDelete(id: string) {
+    const res = await fetch(`/api/todos/${id}`, { method: "DELETE" });
+    if (!res.ok) throw new Error("삭제에 실패했습니다.");
+    setTodos((prev) => prev.filter((t) => t.id !== id));
+  }
+
+  return (
+    <div className="max-w-lg mx-auto px-4 py-12">
+      <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100 mb-8">
+        Todo List
+      </h1>
+
+      <div className="mb-6">
+        <TodoForm onCreate={handleCreate} />
+      </div>
+
+      {loading ? (
+        <p className="text-center text-sm text-gray-400 dark:text-gray-500 py-8">
+          불러오는 중...
+        </p>
+      ) : error ? (
+        <p className="text-center text-sm text-red-500 py-8">{error}</p>
+      ) : (
+        <TodoList todos={todos} onToggle={handleToggle} onDelete={handleDelete} />
+      )}
+    </div>
+  );
+}

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -1,0 +1,34 @@
+import { Todo, UpdateTodoRequest } from "@/types/todo";
+
+const todos = new Map<string, Todo>();
+
+export const todoStore = {
+  getAll(): Todo[] {
+    return Array.from(todos.values()).sort(
+      (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
+    );
+  },
+
+  create(title: string): Todo {
+    const todo: Todo = {
+      id: crypto.randomUUID(),
+      title,
+      completed: false,
+      createdAt: new Date().toISOString(),
+    };
+    todos.set(todo.id, todo);
+    return todo;
+  },
+
+  update(id: string, patch: UpdateTodoRequest): Todo | null {
+    const existing = todos.get(id);
+    if (!existing) return null;
+    const updated = { ...existing, ...patch };
+    todos.set(id, updated);
+    return updated;
+  },
+
+  delete(id: string): boolean {
+    return todos.delete(id);
+  },
+};

--- a/src/types/todo.ts
+++ b/src/types/todo.ts
@@ -1,0 +1,15 @@
+export interface Todo {
+  id: string;
+  title: string;
+  completed: boolean;
+  createdAt: string;
+}
+
+export interface CreateTodoRequest {
+  title: string;
+}
+
+export interface UpdateTodoRequest {
+  completed?: boolean;
+  title?: string;
+}


### PR DESCRIPTION
## 개요
Next.js App Router + In-memory store로 Todo CRUD 기능을 구현합니다.

## 변경사항
- `src/types/todo.ts` - Todo 타입 정의
- `src/lib/store.ts` - In-memory Map 기반 store
- `src/app/api/todos/route.ts` - GET, POST 엔드포인트
- `src/app/api/todos/[id]/route.ts` - PATCH, DELETE 엔드포인트
- `src/components/todos/` - TodoPage, TodoList, TodoItem, TodoForm 컴포넌트
- `src/app/todos/page.tsx` - 라우트 진입점

## 검증
- [ ] `http://localhost:3000/todos` 접속 후 CRUD 동작 확인
- [ ] 빈 제목 추가 시 차단 확인
- [ ] 타입 에러 없음 (tsc --noEmit)

Closes #1